### PR TITLE
Use pop for safe session clearing

### DIFF
--- a/common/session/server_session_manager.py
+++ b/common/session/server_session_manager.py
@@ -7,10 +7,10 @@ class ServerSessionManager:
         server_id = str(server_id)
         self.sessions[server_id] = auth_data
 
-   # 指定サーバーのセッション情報を削除。
+    # 指定サーバーのセッション情報を削除。
     def clear_session(self, server_id: int):
         server_id = str(server_id)
-        self.sessions[server_id] = []
+        self.sessions.pop(server_id, None)
 
     # 指定サーバーのセッション情報を取得。
     def get_session(self, server_id: int):
@@ -21,6 +21,7 @@ class ServerSessionManager:
     def has_session(self, server_id: int) -> bool:
         server_id = str(server_id)
         return server_id in self.sessions
+
 
 # シングルトンとして使うインスタンス
 server_session_manager = ServerSessionManager()

--- a/common/session/user_session_manager.py
+++ b/common/session/user_session_manager.py
@@ -8,10 +8,10 @@ class UserSessionManager:
         auth_data["user_id"] = user_id
         self.sessions[user_id] = auth_data
 
-   # 指定ユーザーIDのセッション情報を削除。
+    # 指定ユーザーIDのセッション情報を削除。
     def clear_session(self, user_id: int):
         user_id = str(user_id)
-        self.sessions[user_id] = []
+        self.sessions.pop(user_id, None)
 
     # 指定ユーザーのセッション情報を取得。
     def get_session(self, user_id: int):
@@ -22,6 +22,7 @@ class UserSessionManager:
     def has_session(self, user_id: int) -> bool:
         user_id = str(user_id)
         return user_id in self.sessions
+
 
 # シングルトンとして使うインスタンス
 user_session_manager = UserSessionManager()

--- a/tests/test_session_managers.py
+++ b/tests/test_session_managers.py
@@ -1,0 +1,27 @@
+import os
+import sys
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from common.session.server_session_manager import ServerSessionManager
+from common.session.user_session_manager import UserSessionManager
+
+
+def test_server_clear_session_removes_session():
+    mgr = ServerSessionManager()
+    mgr.set_session(123, {"provider": "test"})
+    assert mgr.has_session(123)
+    mgr.clear_session(123)
+    assert not mgr.has_session(123)
+    mgr.clear_session(123)
+    assert not mgr.has_session(123)
+
+
+def test_user_clear_session_removes_session():
+    mgr = UserSessionManager()
+    mgr.set_session(456, {"provider": "test"})
+    assert mgr.has_session(456)
+    mgr.clear_session(456)
+    assert not mgr.has_session(456)
+    mgr.clear_session(456)
+    assert not mgr.has_session(456)


### PR DESCRIPTION
## Summary
- avoid KeyError on missing session entries
- add tests for server and user session managers

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6891b88d2c248332b1fb915652960284