### PR TITLE
Hotfix: replace OpenAI vision validator external image

### DIFF
--- a/ai/openai/openai_api.py
+++ b/ai/openai/openai_api.py
@@ -4,6 +4,13 @@ import aiohttp, base64, asyncio, json
 OPENAI_VISION_ENDPOINT = "https://api.openai.com/v1/chat/completions"
 OPENAI_IMAGEGEN_ENDPOINT = "https://api.openai.com/v1/images/generations"
 
+
+def _uses_max_completion_tokens(model_name: str) -> bool:
+    """max_tokensの代わりにmax_completion_tokensが必要なOpenAIモデルか判定する。"""
+    name = (model_name or "").strip().lower()
+    return name.startswith(("gpt-5", "o1", "o3", "o4"))
+
+
 # 認証情報で指定されたAPIを呼び出す
 
 # ChatGPTにメッセージ送信
@@ -12,7 +19,7 @@ async def call_chatgpt(context_list: list[dict], api_key: str, model: str = "gpt
     for msg in context_list:
         if msg.startswith("\s"):
             messages.append({"role": "system", "content": msg.replace("\s", "", 1).strip()})
-        else:   
+        else:
             if msg.startswith("AIChatBot:"):
                 messages.append({"role": "assistant", "content": msg.replace("AIChatBot:", "", 1).strip()})
             else:
@@ -20,11 +27,18 @@ async def call_chatgpt(context_list: list[dict], api_key: str, model: str = "gpt
 
     try:
         client = AsyncOpenAI(api_key=api_key)
-        response = await client.chat.completions.create(
-            model=model,
-            messages=messages,
-            max_tokens=max_tokens
-        )
+
+        payload = {
+            "model": model,
+            "messages": messages,
+        }
+
+        if _uses_max_completion_tokens(model):
+            payload["max_completion_tokens"] = max_tokens
+        else:
+            payload["max_tokens"] = max_tokens
+
+        response = await client.chat.completions.create(**payload)
         return response.choices[0].message.content
     except Exception as e:
         return f"❌ OpenAI 応答エラー: {e}"
@@ -37,7 +51,16 @@ async def analyze_openai_vision(image_urls: list[str], prompt: str, api_key: str
     for u in (image_urls or [])[:8]:
         content.append({"type": "image_url", "image_url": {"url": u}})
 
-    payload = {"model": model, "messages": [{"role": "user", "content": content}], "max_tokens": max_tokens}
+    payload = {
+        "model": model,
+        "messages": [{"role": "user", "content": content}],
+    }
+
+    if _uses_max_completion_tokens(model):
+        payload["max_completion_tokens"] = max_tokens
+    else:
+        payload["max_tokens"] = max_tokens
+
     try:
         async with aiohttp.ClientSession() as sess:
             async with sess.post(OPENAI_VISION_ENDPOINT, json=payload, headers=headers, timeout=aiohttp.ClientTimeout(total=60)) as resp:
@@ -70,14 +93,14 @@ async def generate_image_from_prompt(prompt: str, api_key: str, model: str, size
     }
     if model == "dall-e-3":
         payload["response_format"] = "b64_json"
-    
+
     timeout = aiohttp.ClientTimeout(total=timeout_sec)
     async with aiohttp.ClientSession(timeout=timeout) as session:
         async with session.post(OPENAI_IMAGEGEN_ENDPOINT, headers=headers, json=payload) as resp:
             data = await resp.json()
             if resp.status != 200:
                 raise RuntimeError(f"OpenAI image gen failed: {resp.status} / {data}")
-           
+
         if not data.get("data"):
             raise RuntimeError(f"OpenAI image gen empty response: {data}")
 

--- a/ai/openai/validator.py
+++ b/ai/openai/validator.py
@@ -42,6 +42,21 @@ def _build_openai_vision_test_image_url() -> str:
     return f"data:image/png;base64,{encoded}"
 
 
+def _uses_max_completion_tokens(model_name: str) -> bool:
+    """max_tokensの代わりにmax_completion_tokensが必要なOpenAIモデルか判定する。"""
+    name = (model_name or "").strip().lower()
+    return name.startswith(("gpt-5", "o1", "o3", "o4"))
+
+
+def _set_completion_limit(payload: dict, model_name: str, value: int) -> dict:
+    """モデルに応じて出力トークン数指定パラメータを設定する。"""
+    if _uses_max_completion_tokens(model_name):
+        payload["max_completion_tokens"] = value
+    else:
+        payload["max_tokens"] = value
+    return payload
+
+
 # 共通HTTPユーティリティ
 async def _get_json(session: aiohttp.ClientSession, url: str, headers: dict):
     async with session.get(url, headers=headers, timeout=aiohttp.ClientTimeout(total=10)) as resp:
@@ -82,11 +97,10 @@ async def is_openai_chat_model_available(api_key: str, model_name: str) -> bool:
         "Authorization": f"Bearer {api_key}",
         "Content-Type": "application/json"
     }
-    payload = {
+    payload = _set_completion_limit({
         "model": model_name,
         "messages": [{"role": "user", "content": "ping"}],
-        "max_tokens": 1,
-    }
+    }, model_name, 1)
     try:
         async with aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=10)) as session:
             status, text, _ = await _post_json(session, OPENAI_CHAT_ENDPOINT, headers, payload)
@@ -111,7 +125,7 @@ async def is_openai_vision_model_available(api_key: str, model_name: str) -> boo
         "Authorization": f"Bearer {api_key}",
         "Content-Type": "application/json"
     }
-    payload = {
+    payload = _set_completion_limit({
         "model": model_name,
         "messages": [
             {"role": "user", "content": [
@@ -121,8 +135,7 @@ async def is_openai_vision_model_available(api_key: str, model_name: str) -> boo
                 }}
             ]}
         ],
-        "max_tokens": 10,
-    }
+    }, model_name, 10)
     try:
         async with aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=10)) as session:
             status, text, _ = await _post_json(session, OPENAI_CHAT_ENDPOINT, headers, payload)

--- a/ai/openai/validator.py
+++ b/ai/openai/validator.py
@@ -1,5 +1,9 @@
 import aiohttp
 import json
+import base64
+import binascii
+import struct
+import zlib
 from ai.openai.openai_api import generate_image_from_prompt
 
 # 認証情報で指定されたAPIが利用可能かチェックする
@@ -7,10 +11,36 @@ from ai.openai.openai_api import generate_image_from_prompt
 OPENAI_BASE = "https://api.openai.com/v1"
 OPENAI_MODELS_ENDPOINT = f"{OPENAI_BASE}/models"
 OPENAI_CHAT_ENDPOINT   = f"{OPENAI_BASE}/chat/completions"
-OPENAI_VISION_TEST_IMAGE_URL = (
-    "data:image/png;base64,"
-    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII="
-)
+
+
+def _png_chunk(chunk_type: bytes, data: bytes) -> bytes:
+    """PNGチャンクを作成する。"""
+    length = struct.pack(">I", len(data))
+    crc = struct.pack(">I", binascii.crc32(chunk_type + data) & 0xFFFFFFFF)
+    return length + chunk_type + data + crc
+
+
+def _build_openai_vision_test_image_url() -> str:
+    """OpenAI Vision検証用の小さなPNG画像をdata URLとして生成する。"""
+    width = 32
+    height = 32
+    rows = []
+
+    for y in range(height):
+        row = bytearray()
+        for x in range(width):
+            is_border = (8 <= x <= 24 and y in (8, 24)) or (8 <= y <= 24 and x in (8, 24))
+            row.extend((0, 0, 0) if is_border else (255, 255, 255))
+        rows.append(bytes([0]) + bytes(row))
+
+    raw_image = b"".join(rows)
+    png = b"\x89PNG\r\n\x1a\n"
+    png += _png_chunk(b"IHDR", struct.pack(">IIBBBBB", width, height, 8, 2, 0, 0, 0))
+    png += _png_chunk(b"IDAT", zlib.compress(raw_image))
+    png += _png_chunk(b"IEND", b"")
+    encoded = base64.b64encode(png).decode("ascii")
+    return f"data:image/png;base64,{encoded}"
+
 
 # 共通HTTPユーティリティ
 async def _get_json(session: aiohttp.ClientSession, url: str, headers: dict):
@@ -87,7 +117,7 @@ async def is_openai_vision_model_available(api_key: str, model_name: str) -> boo
             {"role": "user", "content": [
                 {"type": "text", "text": "Describe this image."},
                 {"type": "image_url", "image_url": {
-                    "url": OPENAI_VISION_TEST_IMAGE_URL
+                    "url": _build_openai_vision_test_image_url()
                 }}
             ]}
         ],

--- a/ai/openai/validator.py
+++ b/ai/openai/validator.py
@@ -11,6 +11,8 @@ from ai.openai.openai_api import generate_image_from_prompt
 OPENAI_BASE = "https://api.openai.com/v1"
 OPENAI_MODELS_ENDPOINT = f"{OPENAI_BASE}/models"
 OPENAI_CHAT_ENDPOINT   = f"{OPENAI_BASE}/chat/completions"
+OPENAI_CHAT_VALIDATION_MAX_TOKENS = 64
+OPENAI_VISION_VALIDATION_MAX_TOKENS = 128
 
 
 def _png_chunk(chunk_type: bytes, data: bytes) -> bytes:
@@ -63,7 +65,7 @@ async def _get_json(session: aiohttp.ClientSession, url: str, headers: dict):
         return resp.status, await resp.text(), resp.headers
 
 async def _post_json(session: aiohttp.ClientSession, url: str, headers: dict, payload: dict):
-    async with session.post(url, headers=headers, json=payload, timeout=aiohttp.ClientTimeout(total=12)) as resp:
+    async with session.post(url, headers=headers, json=payload, timeout=aiohttp.ClientTimeout(total=30)) as resp:
         return resp.status, await resp.text(), resp.headers
 
 # APIキーのチェック
@@ -99,10 +101,10 @@ async def is_openai_chat_model_available(api_key: str, model_name: str) -> bool:
     }
     payload = _set_completion_limit({
         "model": model_name,
-        "messages": [{"role": "user", "content": "ping"}],
-    }, model_name, 1)
+        "messages": [{"role": "user", "content": "Reply with OK."}],
+    }, model_name, OPENAI_CHAT_VALIDATION_MAX_TOKENS)
     try:
-        async with aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=10)) as session:
+        async with aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=30)) as session:
             status, text, _ = await _post_json(session, OPENAI_CHAT_ENDPOINT, headers, payload)
             if status == 200:
                 return True
@@ -129,15 +131,15 @@ async def is_openai_vision_model_available(api_key: str, model_name: str) -> boo
         "model": model_name,
         "messages": [
             {"role": "user", "content": [
-                {"type": "text", "text": "Describe this image."},
+                {"type": "text", "text": "Describe this image briefly."},
                 {"type": "image_url", "image_url": {
                     "url": _build_openai_vision_test_image_url()
                 }}
             ]}
         ],
-    }, model_name, 10)
+    }, model_name, OPENAI_VISION_VALIDATION_MAX_TOKENS)
     try:
-        async with aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=10)) as session:
+        async with aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=30)) as session:
             status, text, _ = await _post_json(session, OPENAI_CHAT_ENDPOINT, headers, payload)
             if status == 200:
                 return True

--- a/ai/openai/validator.py
+++ b/ai/openai/validator.py
@@ -7,6 +7,10 @@ from ai.openai.openai_api import generate_image_from_prompt
 OPENAI_BASE = "https://api.openai.com/v1"
 OPENAI_MODELS_ENDPOINT = f"{OPENAI_BASE}/models"
 OPENAI_CHAT_ENDPOINT   = f"{OPENAI_BASE}/chat/completions"
+OPENAI_VISION_TEST_IMAGE_URL = (
+    "data:image/png;base64,"
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII="
+)
 
 # 共通HTTPユーティリティ
 async def _get_json(session: aiohttp.ClientSession, url: str, headers: dict):
@@ -83,7 +87,7 @@ async def is_openai_vision_model_available(api_key: str, model_name: str) -> boo
             {"role": "user", "content": [
                 {"type": "text", "text": "Describe this image."},
                 {"type": "image_url", "image_url": {
-                    "url": "https://upload.wikimedia.org/wikipedia/commons/thumb/4/47/PNG_transparency_demonstration_1.png/640px-PNG_transparency_demonstration_1.png"
+                    "url": OPENAI_VISION_TEST_IMAGE_URL
                 }}
             ]}
         ],


### PR DESCRIPTION
## 概要
OpenAI Vision モデル確認時に Wikipedia の画像 URL を使用していたため、OpenAI 側から取得できないケースが発生していました。

## 修正内容
- 外部 URL の画像参照を廃止
- 実行環境内で完結する data URL の PNG 画像を使用
- OpenAI Vision モデル確認処理を外部サイト依存から切り離し

## 対象
- ai/openai/validator.py

## 影響範囲
- `/ac_auth` 実行時の OpenAI Vision モデル検証のみ
- develop ブランチには未適用
